### PR TITLE
TC_09.14.003 | Manage Jenkins > Security> Verify error message displayed when user entered passwords that did not match

### DIFF
--- a/cypress/e2e/manageJenkinsSecurityCreateUser.cy.js
+++ b/cypress/e2e/manageJenkinsSecurityCreateUser.cy.js
@@ -74,4 +74,28 @@ describe('ManageJenkinsSecurityCreateUser.cy', () => {
       .should('contain', '""')
       .and('contain', manageJenkinsSecurityCreateUser.errorUsername);
   });
+  it('TC_09.14.003 | Manage Jenkins > Security> Verify error message displayed when user entered passwords that did not match', function () {
+    cy.get('a[href="/manage"]').click();
+    cy.get('a[href="securityRealm/"]').click();
+    cy.get('a[href="addUser"]').click();
+    cy.get('#username').type(manageJenkinsSecurityCreateUser.username);
+    cy.get('input[name="password1"]').type(
+      manageJenkinsSecurityCreateUser.password
+    );
+    cy.get('input[name="password2"]').type(
+      manageJenkinsSecurityCreateUser.invalidPassword
+    );
+    cy.get('input[name="fullname"]').type(
+      manageJenkinsSecurityCreateUser.fullName
+    );
+    cy.get('input[name="email"]').type(manageJenkinsSecurityCreateUser.email);
+    cy.get('button[name="Submit"]').click();
+    cy.get('div.error')
+      .should('have.length', 2)
+      .each(($el) => {
+        expect($el.text()).to.include(
+          manageJenkinsSecurityCreateUser.errorPasword
+        );
+      });
+  });
 });

--- a/cypress/fixtures/manageJenkinsSecurityCreateUser.json
+++ b/cypress/fixtures/manageJenkinsSecurityCreateUser.json
@@ -1,8 +1,10 @@
 {
   "username": "JohnKennedy",
   "password": "password",
+  "invalidPassword": "pas",
   "fullName": "John Kennedy",
   "email": "email@gmail.com",
   "expectedUserId": ["admin", "JohnKennedy"],
-  "errorUsername": "is prohibited as a username for security reasons."
+  "errorUsername": "is prohibited as a username for security reasons.",
+  "errorPasword": "Password didn't match"
 }


### PR DESCRIPTION
https://trello.com/c/ojwf7vte/175-tc0914003-manage-jenkins-security-create-user-verify-error-message-displayed-when-user-entered-passwords-that-didnt-match