### PR TITLE
TC_02.08.006 | Dashboard -> Block “Set up a distributed build”>Near "Configure a cloud" is an arrow

### DIFF
--- a/cypress/e2e/check_ARROW_Dd_Set_up_a_distributed_build.cy.js
+++ b/cypress/e2e/check_ARROW_Dd_Set_up_a_distributed_build.cy.js
@@ -20,6 +20,14 @@ describe('check_ARROW_Dd_Set_up_a_distributed_build.cy', () => {
           .should('have.attr', 'd', arrow.d)
     });
 
+    it('TC_02.08.006>Dd>“Set up a distributed build”>Near "Configure a cloud" is an arrow ', () => {
+      cy.get('a[href="cloud/"]').contains('Configure a cloud').should('be.visible')
+      cy.get('a[href="cloud/"] svg').should('be.visible')
+      cy.get('a[href="cloud/"] path')
+        .should('have.attr', 'd', arrow.d)
+   });   
+
+
    
 });
 


### PR DESCRIPTION
https://trello.com/c/iAjhYidE/314-tc0208006-dashboard-block-set-up-a-distributed-buildnear-configure-a-cloud-is-an-arrow