### PR TITLE
TC_04.02.003 | Freestyle > Source Code Management > “None” option is selected by default

### DIFF
--- a/cypress/e2e/freestyleProjectConfig.cy.js
+++ b/cypress/e2e/freestyleProjectConfig.cy.js
@@ -22,4 +22,8 @@ describe('US_04.02 | Freestyle > Source Code Management section', () => {
             expect($el.text()).to.be.eql(data.radioButtonNames[index])
         });
     });
+
+    it('TC_04.02.003 | Freestyle > Source Code Management > “None” option is selected by default', () => {
+        cy.get('#radio-block-0').should('be.checked');
+    });
 });


### PR DESCRIPTION

https://trello.com/c/0Mi9v4Ky/296-tc0402003-freestyle-source-code-management-none-option-is-selected-by-default