### PR TITLE
TC_07.02.003 | Folder > Description > Verify that an empty input for text field appears when hit on “Add description” button

### DIFF
--- a/cypress/e2e/folderDescriptionCheckButtons.cy.js
+++ b/cypress/e2e/folderDescriptionCheckButtons.cy.js
@@ -10,9 +10,6 @@ describe('Folder Description', () => {
         cy.get('#ok-button').click();
         cy.get('#jenkins-name-icon').click();
         cy.get('.jenkins-table__link.model-link.inside').click();
-        //cy.visit(`http://localhost:8080/job/${folderCreation.folderName}/`)
-
-
     })
 
     it('TC_07.02.003 | Verify that an empty input for text field appears when hit on “Add description” button', () => {

--- a/cypress/e2e/folderDescriptionCheckButtons.cy.js
+++ b/cypress/e2e/folderDescriptionCheckButtons.cy.js
@@ -8,17 +8,19 @@ describe('Folder Description', () => {
         cy.get('input#name').type(folderCreation.folderName);
         cy.get('.com_cloudbees_hudson_plugins_folder_Folder').click();
         cy.get('#ok-button').click();
-        cy.visit(`http://localhost:8080/job/${folderCreation.folderName}/`)
+        cy.get('#jenkins-name-icon').click();
+        cy.get('.jenkins-table__link.model-link.inside').click();
+        //cy.visit(`http://localhost:8080/job/${folderCreation.folderName}/`)
 
 
     })
 
     it('TC_07.02.003 | Verify that an empty input for text field appears when hit on “Add description” button', () => {
 
-        cy.url().should('be.equal', `http://localhost:8080/job/${folderCreation.folderName}/`)
+        cy.url().should('include', `/job/${folderCreation.folderName}/`);
         cy.get('#description-link').click();
 
-        cy.get('.jenkins-input').should('exist')
+        cy.get('.jenkins-input').should('be.visible')
     })
 
 })

--- a/cypress/e2e/folderDescriptionCheckButtons.cy.js
+++ b/cypress/e2e/folderDescriptionCheckButtons.cy.js
@@ -1,0 +1,24 @@
+
+import folderCreation from "../fixtures/folderCreation.json";
+
+describe('Folder Description', () => {
+
+    beforeEach('Create new folder', () => {
+        cy.get('a[href= "/view/all/newJob"]').click();
+        cy.get('input#name').type(folderCreation.folderName);
+        cy.get('.com_cloudbees_hudson_plugins_folder_Folder').click();
+        cy.get('#ok-button').click();
+        cy.visit(`http://localhost:8080/job/${folderCreation.folderName}/`)
+
+
+    })
+
+    it('TC_07.02.003 | Verify that an empty input for text field appears when hit on “Add description” button', () => {
+
+        cy.url().should('be.equal', `http://localhost:8080/job/${folderCreation.folderName}/`)
+        cy.get('#description-link').click();
+
+        cy.get('.jenkins-input').should('exist')
+    })
+
+})

--- a/cypress/fixtures/folderCreation.json
+++ b/cypress/fixtures/folderCreation.json
@@ -1,0 +1,4 @@
+{
+    "folderName": "newFolder",
+    "previewHidePreview": "Hide preview"
+}


### PR DESCRIPTION
https://trello.com/c/m35zQf7F/370-tc0702004-folder-description-verify-that-area-with-descriptions-text-appears-and-link-hide-preview-is-visible-when-click-on-prev