### PR TITLE
RF | manageJenkinsSystemConfTools | manageJenkinsTitle | TC_09.06.007 | Verify that the user redirects to '/configureTools' page after clicking on the 'Tools' title | TC_09.01.001 | Manage Jenkins > Title > Main header displays verification

### DIFF
--- a/cypress/e2e/manageJenkinsSystemConfTools.cy.js
+++ b/cypress/e2e/manageJenkinsSystemConfTools.cy.js
@@ -3,7 +3,6 @@
 import manageJenkinsSystemConfToolsData from "../fixtures/manageJenkinsSystemConfTools.json";
 import { manageJenkinsPageEndpoint } from "../fixtures/manageJenkinsTitle.json";
 import { sectionItemsHeaders } from "../fixtures/manageJenkinsTools.json";
-import cypressEnvData from "../../cypress.env.json";
 
 describe("manageJenkinsSystemConfTools", () => {
     beforeEach(() => {
@@ -26,8 +25,8 @@ describe("manageJenkinsSystemConfTools", () => {
     });
 
     it("TC_09.06.007 | Verify that the user redirects to '/configureTools' page after clicking on the 'Tools' title", () => {
-        const baseUrl = `http://${cypressEnvData["local.host"]}:${cypressEnvData["local.port"]}` + "/";
-        const confToolsPageUrl = `${baseUrl}${manageJenkinsPageEndpoint}${manageJenkinsSystemConfToolsData.configureToolsPageEndpoint}`;
+        const baseUrl = `http://${Cypress.env("local.host")}:${Cypress.env("local.port")}`;
+        const confToolsPageUrl = `${baseUrl}/${manageJenkinsPageEndpoint}/${manageJenkinsSystemConfToolsData.configureToolsPageEndpoint}/`;
 
         cy.get("a[href='configureTools'] dl dt").should("be.visible").click();
 
@@ -41,11 +40,11 @@ describe("manageJenkinsSystemConfTools", () => {
 
     it("TC_09.06.009 | Checking the visibility of the title and icon 'Tools'", () => {
         cy.get('.jenkins-section.jenkins-section--bottom-padding')
-          .contains(manageJenkinsSystemConfToolsData.sectionMainHeader)
-          .next()
-          .contains(sectionItemsHeaders.tools)
-          .should('be.visible')
+            .contains(manageJenkinsSystemConfToolsData.sectionMainHeader)
+            .next()
+            .contains(sectionItemsHeaders.tools)
+            .should('be.visible')
         cy.get('a[href="configureTools"] .jenkins-section__item__icon svg.icon')
-          .should('be.visible')       
+            .should('be.visible')
     });
 });

--- a/cypress/e2e/manageJenkinsTitle.cy.js
+++ b/cypress/e2e/manageJenkinsTitle.cy.js
@@ -1,7 +1,6 @@
 /// <reference types="cypress"/>
 
 import manageJenkinsTitleData from "../fixtures/manageJenkinsTitle.json";
-import cypressEnvData from "../../cypress.env.json";
 
 describe("manageJenkinsTitle", () => {
     beforeEach(() => {
@@ -9,8 +8,8 @@ describe("manageJenkinsTitle", () => {
     })
 
     it("TC_09.01.001 | Manage Jenkins > Title > Main header displays verification", () => {
-        const baseUrl = `http://${cypressEnvData["local.host"]}:${cypressEnvData["local.port"]}` + "/";
-        const manageJenkinsPageUrl = `${baseUrl}${manageJenkinsTitleData.manageJenkinsPageEndpoint}`;
+        const baseUrl = `http://${Cypress.env("local.host")}:${Cypress.env("local.port")}`;
+        const manageJenkinsPageUrl = `${baseUrl}/${manageJenkinsTitleData.manageJenkinsPageEndpoint}/`;
 
         cy.url().should("be.eql", manageJenkinsPageUrl);
 

--- a/cypress/fixtures/manageJenkinsSystemConfTools.json
+++ b/cypress/fixtures/manageJenkinsSystemConfTools.json
@@ -1,5 +1,5 @@
 {
-    "configureToolsPageEndpoint": "configureTools/",
+    "configureToolsPageEndpoint": "configureTools",
     "sectionMainHeader" : "System Configuration",
     "sysConfSubHeaders": [
         "System",

--- a/cypress/fixtures/manageJenkinsTitle.json
+++ b/cypress/fixtures/manageJenkinsTitle.json
@@ -1,6 +1,6 @@
 {
   "mainHeaderPage": "Manage Jenkins",
-  "manageJenkinsPageEndpoint": "manage/",
+  "manageJenkinsPageEndpoint": "manage",
   "subHeadersMainJenkinsPage": [
     "System Configuration",
     "Security",


### PR DESCRIPTION
https://trello.com/c/62CuadgO/377-rf-managejenkinssystemconftools-tc0906007-verify-that-the-user-redirects-to-configuretools-page-after-clicking-on-the-tools-titl