### PR TITLE
Changed name of locator "getNewItemLink" and refactor methods and tests with this locator

### DIFF
--- a/cypress/e2e/pom_e2e/buildHistoryFreestyleProject.cy.js
+++ b/cypress/e2e/pom_e2e/buildHistoryFreestyleProject.cy.js
@@ -7,7 +7,7 @@ import BuildHistoryPage from "../../pageObjects/BuildHistoryPage";
 
 describe('Build History of FreestyleProject',function(){
     beforeEach(function(){
-        homePage.clickNewItemLink()
+        homePage.clickCreateAJobLink()
         .fillInputNameField(freestyleProjectData.projectName)
         .clickFreestyleTypeOfProjectBtn()
         .clickOKButtonFreestyle();

--- a/cypress/e2e/pom_e2e/folderConfigure.cy.js
+++ b/cypress/e2e/pom_e2e/folderConfigure.cy.js
@@ -9,7 +9,7 @@ describe("folderConfigure", () => {
 
   beforeEach("createNewFolder", () => {
     homePage
-      .clickNewItemLink()
+      .clickCreateAJobLink()
       .fillInputNameField(folderConfigureData.folderName)
       .clickFolderBtn()
       .clickOKButtonFolder()

--- a/cypress/e2e/pom_e2e/folderDescription.cy.js
+++ b/cypress/e2e/pom_e2e/folderDescription.cy.js
@@ -11,7 +11,7 @@ describe("folderDescription", () => {
 
   beforeEach("createNewFolder", () => {
     homePage
-      .clickNewItemLink()
+      .clickCreateAJobLink()
       .fillInputNameField(folderConfigureData.folderName)
       .clickFolderBtn()
       .clickOKButtonFolder()

--- a/cypress/e2e/pom_e2e/freestyleProjectConfigure.cy.js
+++ b/cypress/e2e/pom_e2e/freestyleProjectConfigure.cy.js
@@ -10,7 +10,7 @@ describe('freestyleProjectConfigure', () => {
     const { sectionName } = data.configure.sourceCodeManagement;
     
     beforeEach(() => {
-        homePage.clickNewItemLink()
+        homePage.clickCreateAJobLink()
                 .fillInputNameField(data.projectName)
                 .clickFreestyleTypeOfProjectBtn()
                 .clickOKButtonFreestyle()

--- a/cypress/e2e/pom_e2e/labelsAtNewJobPage.cy.js
+++ b/cypress/e2e/pom_e2e/labelsAtNewJobPage.cy.js
@@ -7,7 +7,7 @@ describe("labelsAtNewJobPage", () => {
   const homePage = new HomePage();
 
   beforeEach(function () {
-    homePage.clickNewItemLink() 
+    homePage.clickCreateAJobLink() 
             .collectTypeOfProjectLabels(); 
   });
   newJobPageData.typeOfProjectLabelNames.forEach((name, index) => {

--- a/cypress/e2e/pom_e2e/multiconfigProject.cy.js
+++ b/cypress/e2e/pom_e2e/multiconfigProject.cy.js
@@ -7,7 +7,7 @@ describe('multiconfigProject', () => {
     const homePage = new HomePage();
    
     it('Create Multiconfiguration project', function() {
-        homePage.clickNewItemLink()
+        homePage.clickCreateAJobLink()
                 .fillInputNameField(multiconfigProjectData.projectName)
                 .clickMultiConfigTypeOfProjectBtn()
                 .clickOKButtonFreestyle();

--- a/cypress/pageObjects/HomePage.js
+++ b/cypress/pageObjects/HomePage.js
@@ -5,7 +5,7 @@ import ManageJenkinsPage from "../pageObjects/ManageJenkinsPage";
 import PeoplePage from "../pageObjects/PeoplePage";
 const dayjs = require("dayjs");
 class HomePage {
-  getNewItemLink = () => cy.get('a[href="newJob"]');
+  getCreateAJobLink = () => cy.get('a[href="newJob"]');
   getDashboardBreadcrumbsLink = () =>
     cy.get('li.jenkins-breadcrumbs__list-item a[href="/"]');
   getProjectNameLink = () => cy.get('td a[href*="job"].jenkins-table__link');
@@ -21,8 +21,8 @@ class HomePage {
   getNewItemLinkSidePanel = () => cy.get("a[href='/view/all/newJob']");
   getWelcomedMessageHeader = () => cy.get(".empty-state-block h1");
 
-  clickNewItemLink() {
-    this.getNewItemLink().click();
+  clickCreateAJobLink() {
+    this.getCreateAJobLink().click();
 
     return new NewJobPage();
   }


### PR DESCRIPTION
https://trello.com/c/zLPGKkFu/429-rf-change-the-name-of-the-locator-and-methods-in-the-test

It was decided to rename this locator because it is the locator for the "Create a job" element.
The locator for "New Item" can be found in cypress/pageObjects/HomePage.js with the name getNewItemLinkSidePanel


Discussion in Slack https://redroverschool.slack.com/archives/C049HHDG0KF/p1700499264596219