### PR TITLE
TC_04.02.003 | Freestyle > Source Code Management > “None” option is selected by default

### DIFF
--- a/cypress/e2e/pom_e2e/freestyleProjectConfigure.cy.js
+++ b/cypress/e2e/pom_e2e/freestyleProjectConfigure.cy.js
@@ -31,4 +31,8 @@ describe('freestyleProjectConfigure', () => {
                                         expect($el.text()).to.be.eql(radioButtonNames[index])
                                      });    
     });
+
+    it('TC_04.02.003 | Freestyle > Source Code Management > “None” option is selected by default', () => {
+        freestyleProjectConfigurePage.getSrcCodeMngmntNoneOption().should('be.checked')
+    });
 });

--- a/cypress/pageObjects/FreestyleProjectConfigurePage.js
+++ b/cypress/pageObjects/FreestyleProjectConfigurePage.js
@@ -1,5 +1,6 @@
 class FreestyleProjectConfigurePage {
     getSourceCodeManagementSection = () => cy.get('#source-code-management');
+    getSrcCodeMngmntNoneOption = () => cy.get('#radio-block-0');
     getSourceCodeManagementSectionBtns = () => cy.get('#source-code-management').parent().find('[id^=radio-block-]');
     getSourceCodeManagementSectionLbls = () => cy.get('#source-code-management').parent().find('label[for^=radio-block-]');
 


### PR DESCRIPTION
https://trello.com/c/yfJwzAGL/433-rf-tc0402003-freestyle-source-code-management-none-option-is-selected-by-default