### PR TITLE
TC_07.02.009|Folder > Description>Verify text input field appears when hit on “Add description” button

### DIFF
--- a/cypress/e2e/pom_e2e/folderDescription.cy.js
+++ b/cypress/e2e/pom_e2e/folderDescription.cy.js
@@ -36,4 +36,18 @@ describe("folderDescription", () => {
       .and("have.prop", "innerText", folderPageData.saveButtonName);
 
   });
+
+  it("TC_07.02.009 | Verify text input field appears when hit on “Add description” button", () => {
+    folderPage
+      .clickAddDescriptionLink()
+      .getInputField()
+      .should("be.visible")
+      .should("have.value", "");
+
+    folderPage
+      .typeInputField(folderPageData.fDText)
+      .getInputField()
+      .should("have.value", folderPageData.fDText);
+  });
+
 });

--- a/cypress/fixtures/pom_fixtures/folderPageData.json
+++ b/cypress/fixtures/pom_fixtures/folderPageData.json
@@ -1,5 +1,6 @@
 {
     "previewLinkName": "Preview",
     "saveButtonName" : "Save",
-    "addDescriptionButtonName" : "Add description"
+    "addDescriptionButtonName" : "Add description",
+    "fDText": "There is some text information about curent Folder here."
 }

--- a/cypress/pageObjects/FolderPage.js
+++ b/cypress/pageObjects/FolderPage.js
@@ -21,7 +21,12 @@ class FolderPage {
     return this;
   }
 
-  
+  typeInputField(text){
+    this.getInputField().type(text);
+    
+    return this;
+  }
+ 
 }
 
 export default FolderPage;


### PR DESCRIPTION
https://trello.com/c/UDnc1e3W/441-tc0702009folder-descriptionverify-text-input-for-field-appears-when-hit-on-add-description-button 