### PR TITLE
RF | POM > Manage Jenkins > Security > Create user > Verify error message displayed when creating user 

### DIFF
--- a/cypress/e2e/manageJenkinsSecurityCreateUser.cy.js
+++ b/cypress/e2e/manageJenkinsSecurityCreateUser.cy.js
@@ -28,7 +28,7 @@ describe('ManageJenkinsSecurityCreateUser.cy', () => {
     ).should('have.text', manageJenkinsSecurityCreateUser.username);
   });
 
-  it('TC_09.14.002 | Manage Jenkins > Security > Create user > Verify error message displayed when creating user without username', () => {
+  it.skip('TC_09.14.002 | Manage Jenkins > Security > Create user > Verify error message displayed when creating user without username', () => {
     cy.title().should('include', 'Create User');
     cy.get('#username').should('not.have.value');
     cy.get('input[name="password1"]').type(
@@ -47,7 +47,7 @@ describe('ManageJenkinsSecurityCreateUser.cy', () => {
       .and('contain', manageJenkinsSecurityCreateUser.errorUsername);
   });
 
-  it('TC_09.14.003 | Manage Jenkins > Security> Verify error message displayed when user entered passwords that did not match', function () {
+  it.skip('TC_09.14.003 | Manage Jenkins > Security> Verify error message displayed when user entered passwords that did not match', function () {
     cy.get('#username').type(manageJenkinsSecurityCreateUser.username);
     cy.get('input[name="password1"]').type(
       manageJenkinsSecurityCreateUser.password
@@ -86,7 +86,7 @@ describe('ManageJenkinsSecurityCreateUser.cy', () => {
     );
   });
 
-  it('TC_09.14.005 | Manage Jenkins > Security> Create User > Verify error message displayed when user did not enter the email', function () {
+  it.skip('TC_09.14.005 | Manage Jenkins > Security> Create User > Verify error message displayed when user did not enter the email', function () {
     cy.get('#username').type(manageJenkinsSecurityCreateUser.username);
     cy.get('input[name="password1"]').type(
       manageJenkinsSecurityCreateUser.password
@@ -104,7 +104,7 @@ describe('ManageJenkinsSecurityCreateUser.cy', () => {
       manageJenkinsSecurityCreateUser.errorEmail
     );
   });
-  it('TC_09.14.010 | Manage Jenkins > Security> Create User > Verify error message displayed when user enter invalid Username by using special characters', function () {
+  it.skip('TC_09.14.010 | Manage Jenkins > Security> Create User > Verify error message displayed when user enter invalid Username by using special characters', function () {
     cy.get('#username').type(
       JSON.stringify(manageJenkinsSecurityCreateUser.invalidUsername)
     );

--- a/cypress/e2e/pom_e2e/manageJenkinsSecurityCreateUsers.cy.js
+++ b/cypress/e2e/pom_e2e/manageJenkinsSecurityCreateUsers.cy.js
@@ -1,5 +1,6 @@
 /// <reference types="cypress"/>
 
+import { userData } from '../../fixtures/pom_fixtures/createUsersData.json';
 import createUsersData from '../../fixtures/pom_fixtures/createUsersData.json';
 import HomePage from '../../pageObjects/HomePage';
 import ManageJenkinsPage from '../../pageObjects/ManageJenkinsPage';
@@ -13,9 +14,7 @@ describe('ManageJenkinsSecurityCreateUsers.cy', () => {
   const addUserPage = new AddUserPage();
 
   beforeEach(function () {
-    homePage.clickManageJenkinsLink()
-            .clickUsersLink()
-            .clickCreateUserLink();
+    homePage.clickManageJenkinsLink().clickUsersLink().clickCreateUserLink();
   });
 
   it('TC_09.14.001 | Manage Jenkins > Security> Create User using valid credentials', function () {
@@ -33,7 +32,24 @@ describe('ManageJenkinsSecurityCreateUsers.cy', () => {
     });
   });
 
-  it("TC_09.14.007 | Manage Jenkins > Security> Create User > Verify error messages are displayed if the fields are not filled", () => {
+  userData.testName.forEach((item, index) => {
+    it(`${userData.testCaseNumber[index]} |Manage Jenkins > Security > Create user > Verify error message displayed when ${item}`, function () {
+      addUserPage
+        .fillUserNameField(userData.username[index])
+        .fillPasswordField(createUsersData.password)
+        .fillCofirmPasswordField(userData.confirmPassword[index])
+        .fillFullNameFieldd(createUsersData.fullName)
+        .fillEmailAddressField(userData.email[index])
+        .clickButtonCreateUser();
+
+      addUserPage.getArrayOfEmptyFieldsErrorMessages().each(($el, idx) => {
+        const errorMessages = $el.text();
+        expect(errorMessages).to.be.equal(userData.error[index]);
+      });
+    });
+  });
+
+  it('TC_09.14.007 | Manage Jenkins > Security> Create User > Verify error messages are displayed if the fields are not filled', () => {
     addUserPage.clickButtonCreateUser();
     addUserPage.getArrayOfEmptyFieldsErrorMessages().then(($els) => {
       const errorMessages = Cypress.$.makeArray($els).map(

--- a/cypress/fixtures/pom_fixtures/createUsersData.json
+++ b/cypress/fixtures/pom_fixtures/createUsersData.json
@@ -1,4 +1,28 @@
 {
+  "userData": {
+    "testCaseNumber": [
+      "TC_09.14.002",
+      "TC_09.14.003",
+      "TC_09.14.005",
+      "TC_09.14.010"
+    ],
+    "testName": [
+      "creating user without username",
+      "user entered passwords that did not match",
+      "user did not enter the email",
+      "user enter invalid Username by using special characters"
+    ],
+    "username": [" ", "User1", "User2", "@"],
+    "confirmPassword": ["password", "pas", "password", "password"],
+    "email": ["1@gmail.com", "2@gmail.com", " ", "4@gmail.com"],
+    "error": [
+      "\" \" is prohibited as a username for security reasons.",
+      "Password didn't match",
+      "Invalid e-mail address",
+      "User name must only contain alphanumeric characters, underscore and dash"
+    ]
+  },
+
   "username": "JohnKennedy",
   "invalidUsername": "@",
   "password": "password",


### PR DESCRIPTION
Created one RF | POM  by using parameterization for Test Cases:
1. TC_09.14.002 | Manage Jenkins > Security > Create user > Verify error message displayed when creating user without username 
https://trello.com/c/6mGvYZlJ/487-rf-pom-tc0914002-manage-jenkins-security-create-user-verify-error-message-displayed-when-creating-user-without-username  
3. TC_09.14.003 | Manage Jenkins > Security> Create User > Verify error message displayed when user entered passwords that didn't match 
https://trello.com/c/qTxRiOKJ/488-rf-pom-tc0914003-manage-jenkins-security-create-user-verify-error-message-displayed-when-user-entered-passwords-that-didnt-match
5. TC_09.14.005 | Manage Jenkins > Security> Create User > Verify error message displayed when user didn't enter the email
https://trello.com/c/gcFXvS2a/486-rf-pom-tc0914005-manage-jenkins-security-create-user-verify-error-message-displayed-when-user-didnt-enter-the-email
8. TC_09.14.010 | Manage Jenkins > Security> Create User > Verify error message displayed when user enter invalid Username by using special characters
https://trello.com/c/CpqJ0Qnj/489-rf-pom-tc0914010-manage-jenkins-security-create-user-verify-error-message-displayed-when-user-enter-invalid-username-by-using-sp