### PR TITLE
RF | POM > TC_09.14.004 | Manage Jenkins > Security> Create User > Verify Auto-Fill "Full Name" field with Username If the user leaves "Full name" field empty

### DIFF
--- a/cypress/e2e/manageJenkinsSecurityCreateUser.cy.js
+++ b/cypress/e2e/manageJenkinsSecurityCreateUser.cy.js
@@ -69,7 +69,7 @@ describe('ManageJenkinsSecurityCreateUser.cy', () => {
       });
   });
 
-  it('TC_09.14.004 |Manage Jenkins > Security> Create User > Verify Auto-Fill "Full Name" field with Username If the user leaves "Full name" field empty', function () {
+  it.skip('TC_09.14.004 |Manage Jenkins > Security> Create User > Verify Auto-Fill "Full Name" field with Username If the user leaves "Full name" field empty', function () {
     cy.get('#username').type(manageJenkinsSecurityCreateUser.username);
     cy.get('input[name="password1"]').type(
       manageJenkinsSecurityCreateUser.password

--- a/cypress/e2e/pom_e2e/manageJenkinsSecurityCreateUsers.cy.js
+++ b/cypress/e2e/pom_e2e/manageJenkinsSecurityCreateUsers.cy.js
@@ -60,4 +60,15 @@ describe('ManageJenkinsSecurityCreateUsers.cy', () => {
       );
     });
   });
+
+  it('TC_09.14.004 |Manage Jenkins > Security> Create User > Verify Auto-Fill "Full Name" field with Username If the user leaves "Full name" field empty', function () {
+    addUserPage
+      .fillUserNameField(createUsersData.username)
+      .fillPasswordField(createUsersData.password)
+      .fillCofirmPasswordField(createUsersData.password)
+      .fillEmailAddressField(createUsersData.email)
+      .clickButtonCreateUser();
+
+    userPage.getCreatedName().should('have.text', createUsersData.username);
+  });
 });

--- a/cypress/pageObjects/UserPage.js
+++ b/cypress/pageObjects/UserPage.js
@@ -2,6 +2,7 @@ import AddUserPage from '../pageObjects/AddUserPage';
 class UserPage {
   getCreateUserLink = () => cy.get('a[href="addUser"]');
   getCreatedUser = () => cy.get('td a[href*="user"].jenkins-table__link');
+  getCreatedName = () => cy.get('tbody > :nth-child(2) > :nth-child(3)');
 
   clickCreateUserLink() {
     this.getCreateUserLink().click();


### PR DESCRIPTION
https://trello.com/c/qTxRiOKJ/488-rf-pom-tc0914003-manage-jenkins-security-create-user-verify-error-message-displayed-when-user-entered-passwords-that-didnt-match